### PR TITLE
Add an endpoint for listing plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The idea is that a client could check the hashes against their existing files to
 
   * `GET /plugin/{name}/{version}` - Get hashes for a plugin from wordpress.org
   * `POST /plugin/{name}/{version}/diff` - Compare a client hash against a wordpress.org hash (Not Implemented)
-  * `GET /plugin` - List of plugins we have hashed versions of (Not Implemented)
+  * `GET /plugin` - List of plugins we have hashed versions of
   * `GET /plugin/{name}` - List of versions we have hashed
 
 # Binary Encoding


### PR DESCRIPTION
This currently lists the plugins very simply as a JSON array of plugin
names. With this name, you could then crawl the `/plugin/{name}`
endpoint for each of the plugins in the array to get the versions that
we have hashed.