### PR TITLE
Add diffing of hashes against the reference set in the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The idea is that a client could check the hashes against their existing files to
 # Endpoints
 
   * `GET /plugin/{name}/{version}` - Get hashes for a plugin from wordpress.org
-  * `POST /plugin/{name}/{version}/diff` - Compare a client hash against a wordpress.org hash (Not Implemented)
+  * `POST /plugin/{name}/{version}/diff` - Compare a client hash against a wordpress.org hash
   * `GET /plugin` - List of plugins we have hashed versions of
   * `GET /plugin/{name}` - List of versions we have hashed
 

--- a/shared/structs.go
+++ b/shared/structs.go
@@ -1,5 +1,22 @@
 package shared
 
+type Diff struct {
+	Plugin  *DiffName  `json:"plugin,omitempty"`
+	Version *DiffName  `json:"version,omitempty"`
+	Files   []DiffFile `json:"files"`
+}
+
+type DiffFile struct {
+	Path          string  `json:"path"`
+	ReferenceHash *uint32 `json:"reference"`
+	GivenHash     *uint32 `json:"given"`
+}
+
+type DiffName struct {
+	ReferenceName *string  `json:"reference"`
+	GivenName     *string `json:"given"`
+}
+
 type File struct {
 	Path  string `json:"path"`
 	Error error  `json:"error,omitempty"`
@@ -22,4 +39,46 @@ func (s *Scan) AddHashed(path string, hash uint32) {
 
 func (s *Scan) AddErrored(path string, err error) {
 	s.Files = append(s.Files, File{path, err, 0})
+}
+
+func (s *Scan) Diff(other *Scan) *Diff {
+	diff := Diff{nil, nil, []DiffFile{}}
+	diff.AddName(s.Plugin, other.Plugin)
+	diff.AddVersion(s.Version, other.Version)
+
+	for _, otherFile := range other.Files {
+		found := false
+
+		for _, file := range s.Files {
+			if file.Path == otherFile.Path {
+				if file.Hash != otherFile.Hash {
+					diff.AddFile(file.Path, &file.Hash, &otherFile.Hash)
+				}
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			diff.AddFile(otherFile.Path, nil, &otherFile.Hash)
+		}
+	}
+
+	return &diff
+}
+
+func (d *Diff) AddFile(path string, reference *uint32, given *uint32) {
+	d.Files = append(d.Files, DiffFile{path, reference, given})
+}
+
+func (d *Diff) AddName(reference string, given string) {
+	if reference != given {
+		d.Plugin = &DiffName{&reference, &given}
+	}
+}
+
+func (d *Diff) AddVersion(reference string, given string) {
+	if reference != given {
+		d.Version = &DiffName{&reference, &given}
+	}
 }


### PR DESCRIPTION
This is the simplest diff that made sense to me. It compares the plugin name and version (from the scan that the client does) against the plugin and version from the URL and the file hash list from the scan that happens when you go to `/plugin/{plugin}/{version}`.

Because there is some filtering that happens (to filter out the readme, license, etc.) on the server side, this only does a one-way comparison from the client's scan to the reference scan on the server. That means it checks that the files that are on the client haven't been modified from their reference versions, but it doesn't ensure that all of the PHP files that _should_ be there are actually there.

I'm not sure if we care if the client deletes any files or not. It could indicate that the plugin won't work, but likely doesn't indicate that the plugin has suffered a hack or any other sort of corruption.

Sample response:

```json
{
    "plugin": {
        "reference": "akismet",
        "given": "akismeet"
    },
    "version": {
        "reference": "4.0",
        "given": "4.1"
    },
    "files": [
        {
            "path": "akismet/bob.php",
            "reference": null,
            "given": 1234
        },
        {
            "path": "akismet/akismet.php",
            "reference": 2637562997,
            "given": 778818534
        }
    ]
}
```